### PR TITLE
feat(Issue 15): reset group stats from bot configuration

### DIFF
--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/group/StartTimeResetEvent.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/group/StartTimeResetEvent.java
@@ -1,0 +1,18 @@
+package dev.rubasace.linkedin.games.ldrbot.group;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class StartTimeResetEvent extends ApplicationEvent {
+    private final Long chatId;
+    private final LocalDateTime resetTime;
+
+    public StartTimeResetEvent(final Object source, final Long chatId, final LocalDateTime resetTime) {
+        super(source);
+        this.chatId = chatId;
+        this.startDate = resetTime;
+    }
+}

--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/group/TelegramGroup.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/group/TelegramGroup.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @Setter
@@ -40,6 +41,8 @@ public class TelegramGroup {
     private String uuid;
 
     private String groupName;
+
+    private LocalDateTime startDate;
 
     @Column(nullable = false)
     private ZoneId timezone = ZoneId.of(DEFAULT_ZONE);
@@ -67,6 +70,7 @@ public class TelegramGroup {
     public TelegramGroup(final Long chatId, final String groupName) {
         this.chatId = chatId;
         this.groupName = groupName;
+        this.startDate = new LocalDateTime();
     }
 
     @Override

--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/group/TelegramGroupService.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/group/TelegramGroupService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
 import java.util.Set;
@@ -161,5 +162,14 @@ public class TelegramGroupService {
         telegramGroup.setTimezone(timezone);
         telegramGroupRepository.save(telegramGroup);
         applicationEventPublisher.publishEvent(new TimezoneChangedEvent(this, chatId, timezone));
+    }
+
+    @Transactional
+    public void resetStartTime(final Long chatId) throws GroupNotFoundException {
+        TelegramGroup telegramGroup = findGroupOrThrow(chatId);
+        LocalDateTime now = new LocalDateTime();
+        telegramGroup.setStartTime(now);
+        telegramGroupRepository.save(telegramGroup);
+        applicationEventPublisher.publishEvent(new StartTimeResetEvent(this, chatId, now));
     }
 }

--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/message/config/ConfigureAbility.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/message/config/ConfigureAbility.java
@@ -107,6 +107,9 @@ public class ConfigureAbility extends BaseMessageReplier implements AbilityExten
             case "timezone":
                 showTimezoneConfig(chatId, messageId);
                 return;
+            case "reset-group-stats":
+                showResetGroupStatsConfig(chatId, messageId);
+                return;
             case "back":
                 showMainConfig(chatId, messageId);
                 return;
@@ -139,6 +142,7 @@ public class ConfigureAbility extends BaseMessageReplier implements AbilityExten
         InlineKeyboardMarkup buttons = KeyboardMarkupUtils.createTwoColumnLayout(getPrefix(),
                                                                                  KeyboardMarkupUtils.ButtonData.of("tracked-games", "Tracked Games"),
                                                                                  KeyboardMarkupUtils.ButtonData.of("timezone", "Timezone"),
+                                                                                 KeyboardMarkupUtils.ButtonData.of("reset-group-stats", "Reset Group Stats"),
                                                                                  EXIT_BUTTON);
 
         customTelegramClient.sendOrEditMessage(chatId, "Configuration - Choose an option:", buttons, messageId);
@@ -166,6 +170,23 @@ public class ConfigureAbility extends BaseMessageReplier implements AbilityExten
     private void showTimezoneConfig(final Long chatId, final Integer messageId) {
         this.pendingActions.put(chatId, this::setTimezone);
         customTelegramClient.sendMessage("Please send me your timezone (for example: <code>Europe/London</code> or <code>America/New_York</code>):", chatId);
+    }
+
+    private void showResetGroupStatsConfig(final Long chatId, final Integer messageId) {
+        InlineKeyboardMarkup buttons = KeyboardMarkupUtils.createTwoColumnLayout(getPrefix(),
+                                                                                 KeyboardMarkupUtils.ButtonData.of("yes", "Yes"),
+                                                                                 KeyboardMarkupUtils.ButtonData.of("back", "<< Back to Main Configuration"));
+
+        customTelegramClient.sendOrEditMessage(chatId, "Are you sure you want to reset group stats?", buttons, messageId);
+    }
+
+    private void handleResetGroupStats(final Long chatId, final Integer messageId, final String action) {
+        if ("yes".equals(action)) {
+            telegramGroupService.resetStartTime(chatId);
+            showMainConfig(chatId, messageId);
+        } else if ("back".equals(action)) {
+            showMainConfig(chatId, messageId);
+        }
     }
 
     private KeyboardMarkupUtils.ButtonData gameTypeToAction(final GameType gameType, final Set<GameType> trackedGames) {

--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/web/stats/StatsRepository.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/web/stats/StatsRepository.java
@@ -23,6 +23,7 @@ public interface StatsRepository extends Repository<GameSession, Long> {
                 JOIN s.gameSession gs
                 WHERE s.group.uuid = :groupId
                   AND s.game IN :trackedGames
+                  AND gs.registeredAt > s.group.startDate
                 ORDER BY s.game, s.gameDay ASC, gs.registeredAt ASC
             """)
     Stream<GameSessionProjection> findSessionsPerGame(@Param("groupId") String groupId, @Param("trackedGames") Set<GameType> trackedGames);


### PR DESCRIPTION
Related to Issue: https://github.com/rubasace/ldrbot/issues/15

I have very little knowledge about the DB or the bot's config, but my approach has gone for a soft reset instead of a hard reset. I haven't tested it either, I don't think I have a way to.

Thank you for taking a look at this! 