### PR TITLE
fix: correct override command suggestion in error message

### DIFF
--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/message/ExceptionHandler.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/message/ExceptionHandler.java
@@ -14,13 +14,13 @@ import org.springframework.stereotype.Component;
 class ExceptionHandler {
 
     private static final String ALREADY_REGISTERED_SESSION_MESSAGE_TEMPLATE = "%s already registered a time for %s. If you need to override the time, please delete the current time through the \"/delete <game>\" command. In this case: /delete %s. Alternatively, you can delete all your submissions for the day using /deleteall";
-    public static final String GAME_DURATION_EXCEPTION_MESSAGE_TEMPLATE = "%s submitted a screenshot for the gameInfo %s, but I couldn’t extract the solving time. This often happens if the image is cropped or covered by overlays like confetti. Try sending a clearer screenshot, or ask an admin to set your time manually using /override %s <time>";
+    public static final String GAME_DURATION_EXCEPTION_MESSAGE_TEMPLATE = "%s submitted a screenshot for the gameInfo %s, but I couldn't extract the solving time. This often happens if the image is cropped or covered by overlays like confetti. Try sending a clearer screenshot, or ask an admin to set your time manually using /override @<username> %s <mm:ss>";
     public static final String USER_NOT_FOUND_EXCEPTION_MESSAGE_TEMPLATE = "User %s not found";
 
     private static final String UNKNOWN_COMMAND_MESSAGE_TEMPLATE = """
-            🤖 Sorry, I don’t recognize the command %s.
-            
-            
+            🤖 Sorry, I don't recognize the command %s.
+
+
             """ + ChatConstants.HELP_SUGGESTION;
     public static final String GAME_NOT_FOUND_EXCEPTION_MESSAGE = "'%s' is not a valid game name.";
 


### PR DESCRIPTION
Fixes the misleading command suggestion when the bot fails to extract time from a screenshot.

**Changes:**
- Updated error message to show correct command syntax: `/override @<username> <game> <mm:ss>`
- Previously suggested `/override <game> <time>` which was missing the required username parameter

**Testing:**
- Code change is a string literal update (no functional logic modified)
- Error message now matches the actual command signature defined in OverrideAbility

Closes #12