### PR TITLE
feat: use message timestamp instead of processing time

### DIFF
--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/message/MessageService.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/message/MessageService.java
@@ -23,6 +23,7 @@ import org.telegram.telegrambots.meta.api.objects.commands.BotCommand;
 import org.telegram.telegrambots.meta.api.objects.message.Message;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -130,7 +131,8 @@ class MessageService {
             return;
         }
         if (userInfo == null) userInfo = userAdapter.adapt(message.getFrom());
-        gameSessionService.recordGameSession(chatInfo, userInfo, gameDuration.get(), LinkedinTimeUtils.todayGameDay());
+        Instant messageTimestamp = Instant.ofEpochSecond(message.getDate());
+        gameSessionService.recordGameSession(chatInfo, userInfo, gameDuration.get(), LinkedinTimeUtils.todayGameDay(), messageTimestamp, false);
     }
 
     private boolean isBotRemovedFromGroup(final Message message) {

--- a/src/main/java/dev/rubasace/linkedin/games/ldrbot/session/GameSessionService.java
+++ b/src/main/java/dev/rubasace/linkedin/games/ldrbot/session/GameSessionService.java
@@ -37,11 +37,16 @@ public class GameSessionService {
 
     @Transactional
     public void recordGameSession(final ChatInfo chatInfo, final UserInfo userInfo, final GameDuration gameDuration, final LocalDate gameDay) throws SessionAlreadyRegisteredException, GroupNotFoundException {
-        recordGameSession(chatInfo, userInfo, gameDuration, gameDay, false);
+        recordGameSession(chatInfo, userInfo, gameDuration, gameDay, Instant.now(), false);
     }
 
     @Transactional
     public void recordGameSession(final ChatInfo chatInfo, final UserInfo userInfo, final GameDuration gameDuration, final LocalDate gameDay, final boolean allowOverride) throws SessionAlreadyRegisteredException, GroupNotFoundException {
+        recordGameSession(chatInfo, userInfo, gameDuration, gameDay, Instant.now(), allowOverride);
+    }
+
+    @Transactional
+    public void recordGameSession(final ChatInfo chatInfo, final UserInfo userInfo, final GameDuration gameDuration, final LocalDate gameDay, final Instant messageTimestamp, final boolean allowOverride) throws SessionAlreadyRegisteredException, GroupNotFoundException {
         TelegramGroup telegramGroup = telegramGroupService.findGroupOrThrow(chatInfo);
         TelegramUser telegramUser = telegramUserService.findOrCreate(userInfo);
         if (!telegramGroup.getTrackedGames().contains(gameDuration.type())) {
@@ -65,7 +70,7 @@ public class GameSessionService {
             gameSession.setGroup(telegramGroup);
             gameSession.setGameDay(gameDay);
             gameSession.setDuration(gameDuration.duration());
-            gameSession.setRegisteredAt(Instant.now());
+            gameSession.setRegisteredAt(messageTimestamp);
         }
 
         saveSession(chatInfo, userInfo, gameDay, gameSession, gameInfo, telegramGroup);


### PR DESCRIPTION
When registering game sessions, use the timestamp from the Telegram message (when it was sent) instead of the current time (when the bot processes it).

This ensures that if the bot is down temporarily, game results registered after reconnection will reflect the correct submission time.

## Changes

- Add `messageTimestamp` parameter to `GameSessionService.recordGameSession`
- Extract message timestamp in `MessageService` and pass it downstream
- Preserve backward compatibility with overloaded methods (existing code using the old signature continues to work)

## Testing

CI will verify that existing tests pass. Manual testing can be done by:
1. Stopping the bot
2. Sending a game result
3. Starting the bot (it will process the message)
4. Verifying the `registeredAt` timestamp matches the message send time, not the processing time

Closes #19